### PR TITLE
[Feature] Implementa Versionamento da API 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,16 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+    app.enableVersioning({
+        type: VersioningType.URI,
+        defaultVersion: '1'
+    })
 
   // isso aqui faz com que as rotas da API possam ser validadas durante as chamadas.
   app.useGlobalPipes(new ValidationPipe());


### PR DESCRIPTION
Adicionar o versionamento de rotas na API para garantir a manutenibilidade e a capacidade de evoluir a aplicação sem quebrar a compatibilidade com clientes existentes, cumprindo o requisito final ID18.

✅ Tarefas:

[x] Habilitar o versionamento global da API no arquivo main.ts.
[x] Configurar o tipo de versionamento como URI (ex: /v1/...).
[x] Definir a versão padrão da API como '1'.
[x] Validar se todas as rotas e a documentação Swagger agora respondem sob o prefixo /v1.